### PR TITLE
Add CodeEditor support for syntax highlighting when editing navigations

### DIFF
--- a/docs/extension/Integration-With-Other-Extensions.md
+++ b/docs/extension/Integration-With-Other-Extensions.md
@@ -1,7 +1,6 @@
 # Integration with other extensions
 These are the extensions that StructuredNavigation currently integrates with.
-
- - **CodeMirror**: When you're using CodeMirror, the `mw-navigation` parser tag will have syntax highlighting.
+ - **CodeEditor**: When editing navigations in the Navigation namespace, CodeEditor will provide syntax highlighting for the content as JSON.
  - **TemplateStyles**: No technical integrations, but this extensions works quite smoothly with TemplateStyles for adding custom styles to navigations. A [guide is available](./Styling-with-TemplateStyles.md) for learning how to do this.
 
 ## Planned, upcoming integrations

--- a/extension.json
+++ b/extension.json
@@ -36,6 +36,7 @@
 	},
 	"Hooks": {
 		"BeforeDisplayNoArticleText": "StructuredNavigation\\Hooks\\HookHandler::onBeforeDisplayNoArticleText",
+		"CodeEditorGetPageLanguage": "StructuredNavigation\\Hooks\\HookHandler::onCodeEditorGetPageLanguage",
 		"ParserFirstCallInit": "StructuredNavigation\\Hooks\\HookHandler::onParserFirstCallInit",
 		"UserGetReservedNames": "StructuredNavigation\\Hooks\\HookHandler::onUserGetReservedNames"
 	},

--- a/src/Hooks/HookHandler.php
+++ b/src/Hooks/HookHandler.php
@@ -5,6 +5,7 @@ namespace StructuredNavigation\Hooks;
 use Article;
 use Parser;
 use StructuredNavigation\Services\Services;
+use Title;
 
 /**
  * @license MIT
@@ -20,6 +21,21 @@ final class HookHandler {
 	 */
 	public static function onBeforeDisplayNoArticleText( Article $article ) : bool {
 		return ( new BeforeDisplayNoArticleTextHandler( $article ) )->getHandler();
+	}
+
+	/**
+	 * @see https://www.mediawiki.org/wiki/Extension:CodeEditor/Hooks/CodeEditorGetPageLanguage
+	 * @param Title $title
+	 * @param string|null &$lang
+	 * @return bool
+	 */
+	public static function onCodeEditorGetPageLanguage( Title $title, ?string &$lang ) {
+		if ( $title->hasContentModel( 'StructuredNavigation' ) ) {
+			$lang = 'json';
+			return false;
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
 - Updated documentation (also remove outdated docs for CodeMirror, follow-up to 9caccbc)